### PR TITLE
Car Post Type Canges

### DIFF
--- a/app/PostTypes/Car.php
+++ b/app/PostTypes/Car.php
@@ -22,8 +22,8 @@ class Car {
 
             $carData = [
                 'title' => get_the_title($carID),
-                'description' => $carDetails['description'],
-                'car_image' => $carDetails['car_image'],
+                'description' => apply_filters('the_content', get_the_content($carID)), 
+                'car_image' => get_the_post_thumbnail_url($carID, 'full'),
                 'car_features' => $carDetails['car_features']
             ];
 
@@ -34,3 +34,4 @@ class Car {
         
     }
 }
+

--- a/app/acf-json/car_details.json
+++ b/app/acf-json/car_details.json
@@ -20,51 +20,6 @@
                 "layout": "block",
                 "sub_fields": [
                     {
-                        "key": "field_66c0f06f9d809",
-                        "label": "Description",
-                        "name": "description",
-                        "aria-label": "",
-                        "type": "wysiwyg",
-                        "instructions": "",
-                        "required": 0,
-                        "conditional_logic": 0,
-                        "wrapper": {
-                            "width": "",
-                            "class": "",
-                            "id": ""
-                        },
-                        "default_value": "",
-                        "tabs": "all",
-                        "toolbar": "full",
-                        "media_upload": 1,
-                        "delay": 0
-                    },
-                    {
-                        "key": "field_66c0f08c9d80a",
-                        "label": "Car Image",
-                        "name": "car_image",
-                        "aria-label": "",
-                        "type": "image",
-                        "instructions": "",
-                        "required": 0,
-                        "conditional_logic": 0,
-                        "wrapper": {
-                            "width": "",
-                            "class": "",
-                            "id": ""
-                        },
-                        "return_format": "array",
-                        "library": "all",
-                        "min_width": "",
-                        "min_height": "",
-                        "min_size": "",
-                        "max_width": "",
-                        "max_height": "",
-                        "max_size": "",
-                        "mime_types": "",
-                        "preview_size": "medium"
-                    },
-                    {
                         "key": "field_66c0f0a29d80b",
                         "label": "Car Features",
                         "name": "car_features",

--- a/functions.php
+++ b/functions.php
@@ -42,6 +42,13 @@ function remove_editor_from_page() {
 }
 add_action('init', 'remove_editor_from_page');
 
+function my_theme_setup() {
+    // Enable support for Post Thumbnails on posts and pages
+    add_theme_support('post-thumbnails');
+}
+add_action('after_setup_theme', 'my_theme_setup');
+
+
 //! Check if acf field plugin is active
 include_once(ABSPATH . 'wp-admin/includes/plugin.php');
 if (!is_plugin_active('advanced-custom-fields-pro/acf.php')) {
@@ -152,9 +159,11 @@ add_action( 'init', function() {
 	'menu_position' => 30,
 	'menu_icon' => 'dashicons-car',
 	'supports' => array(
-		0 => 'title',
-		1 => 'revisions',
-	),
+            0 => 'title',
+            1 => 'editor',
+            2 => 'thumbnail',
+            4 => 'revisions'
+        ),
 	'delete_with_user' => false,
 ) );
 } );
@@ -189,4 +198,3 @@ add_action( 'init', function() {
 		'show_in_rest' => true,
 	) );
 } );
-

--- a/views/templates/single-car.twig
+++ b/views/templates/single-car.twig
@@ -19,7 +19,7 @@
       <!-- Car Image Section -->
       <div class="relative w-full md:w-4/5 flex justify-center">
         <div class="md:bg-gray-100 bg-transparent rounded-lg md:p-5 md:shadow-md w-full flex justify-center">
-        <img src="{{ car.car_image.url }}" class="w-full h-auto object-contain md:w-4/5 rounded-xl">
+        <img src="{{ car.car_image }}" class="w-full h-auto object-contain md:w-4/5 rounded-xl">
        </div>
       </div>
 </div>


### PR DESCRIPTION
I changed the source of the images to come from the feature image and the text description to come from the editor instead of the description from the field group. To test this, first apply the ACF changes. Then, in WP, go to the Cars post type. Next, add a post where you include the name of the car, description, features image, and features. For the features, add icons and descriptions. https://imgur.com/a/U4WN4wt