### PR TITLE
Yzer/multilingual fix

### DIFF
--- a/app/Includes/Setup.php
+++ b/app/Includes/Setup.php
@@ -222,7 +222,7 @@ class Setup {
             ob_start();
             comment_form([
                 'submit_button' => '<button class="%1$s-button-c">Post your Comment</button>',
-                'submit_field' => '<div class="form-submit-wrapper flex flex-col md:flex-row items-center space-y-4 md:space-y-0 md:space-x-4">%1$s<div class="g-recaptcha mt-4 md:mt-0 mx-auto md:mx-0" data-sitekey="6LeB-lYqAAAAAGlv_cbcO_yZJsR84yhv2mk65DSU"></div>%2$s</div>',
+                'submit_field' => '<div class="form-submit-wrapper flex flex-col md:flex-row items-center space-y-4 md:space-y-0 md:space-x-4">%1$s<div class="g-recaptcha mt-4 md:mt-0 mx-auto md:mx-0" data-sitekey="YOUR_RECAPTCHA_SITE_KEY_HERE_V2"></div>%2$s</div>',
                 'comment_field' => '<div class="comment-text-h mb-4"><label for="comment" class="block text-sm font-medium">Your Comment:</label><textarea id="comment" name="comment" class="comment-text-area-c" rows="6" required></textarea></div>',
                 'fields' => [
                     'author' => '<div class="mb-4"><label for="author" class="block text-sm font-medium text-gray-700">Name</label><input type="text" id="author" name="author" class="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"></div>',

--- a/app/Includes/Setup.php
+++ b/app/Includes/Setup.php
@@ -222,7 +222,7 @@ class Setup {
             ob_start();
             comment_form([
                 'submit_button' => '<button class="%1$s-button-c">Post your Comment</button>',
-                'submit_field' => '<div class="form-submit-wrapper flex flex-col md:flex-row items-center space-y-4 md:space-y-0 md:space-x-4">%1$s<div class="g-recaptcha mt-4 md:mt-0 mx-auto md:mx-0" data-sitekey="YOUR_RECAPTCHA_SITE_KEY_HERE_V2"></div>%2$s</div>',
+                'submit_field' => '<div class="form-submit-wrapper flex flex-col md:flex-row items-center space-y-4 md:space-y-0 md:space-x-4">%1$s<div class="g-recaptcha mt-4 md:mt-0 mx-auto md:mx-0" data-sitekey="6LeB-lYqAAAAAGlv_cbcO_yZJsR84yhv2mk65DSU"></div>%2$s</div>',
                 'comment_field' => '<div class="comment-text-h mb-4"><label for="comment" class="block text-sm font-medium">Your Comment:</label><textarea id="comment" name="comment" class="comment-text-area-c" rows="6" required></textarea></div>',
                 'fields' => [
                     'author' => '<div class="mb-4"><label for="author" class="block text-sm font-medium text-gray-700">Name</label><input type="text" id="author" name="author" class="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"></div>',

--- a/app/acf-json/header-section.json
+++ b/app/acf-json/header-section.json
@@ -125,6 +125,7 @@
                                 "collapsed": "",
                                 "button_label": "Add Row",
                                 "rows_per_page": 20,
+                                "parent_repeater": "field_66bb59f98c121",
                                 "sub_fields": [
                                     {
                                         "key": "field_66bf20ec24a17",
@@ -165,10 +166,29 @@
                                         "placeholder": "",
                                         "parent_repeater": "field_66bf20c324a16"
                                     }
-                                ],
-                                "parent_repeater": "field_66bb59f98c121"
+                                ]
                             }
                         ]
+                    },
+                    {
+                        "key": "field_6708086b865cf",
+                        "label": "Language Switcher",
+                        "name": "language_switcher",
+                        "aria-label": "",
+                        "type": "wysiwyg",
+                        "instructions": "Please add language switcher short code,\r\ndefault: [language-switcher]",
+                        "required": 0,
+                        "conditional_logic": 0,
+                        "wrapper": {
+                            "width": "",
+                            "class": "",
+                            "id": ""
+                        },
+                        "default_value": "[language-switcher]",
+                        "tabs": "all",
+                        "toolbar": "full",
+                        "media_upload": 1,
+                        "delay": 0
                     }
                 ]
             }
@@ -192,3 +212,4 @@
         "description": "",
         "show_in_rest": 0
     }
+]

--- a/assets/scss/Modules/language-switcher.scss
+++ b/assets/scss/Modules/language-switcher.scss
@@ -1,0 +1,7 @@
+.trp-ls-shortcode-language, .trp-ls-shortcode-current-language {
+    max-width: 80px;
+}
+
+.trp-language-switcher{
+    width:80px;
+}

--- a/assets/scss/front.scss
+++ b/assets/scss/front.scss
@@ -16,6 +16,7 @@
 @import "./Modules/child-comment.scss";
 @import "./Modules/comment-form.scss";
 @import "./Modules/child-comments.scss";
+@import "./Modules/language-switcher.scss";
 
 @import "./style-dark.scss";
 @import "./style-light.scss";

--- a/views/navigation/HeaderNavigation.twig
+++ b/views/navigation/HeaderNavigation.twig
@@ -6,6 +6,10 @@
             </a>
         </div>
 
+    <div class="absolute right-0 mr-16 sm:-mr-8 sm:w-80">
+        {{ data.language_switcher|raw }}
+    </div>
+
         <nav class="flex-grow hidden md:flex justify-center">
             <ul class="flex space-x-6">
                 {% for page in data.header_pages %}
@@ -32,6 +36,8 @@
                     </li>
                 {% endfor %}
             </ul>
+
+
            <!-- Login/Logout button here, outside the loop -->
 <div class="absolute right-0 mr-16">
     {% if data.is_logged_in %}


### PR DESCRIPTION
Fixed language selection menu:

How to test: 1. Import header-section.json ACF. 
2. Go to WP Dashboard left sidebar and select Header Seetings 
4. Scroll down you'll find Language Switcher Seciton 
5. 4. Paste this shortcode: [language-switcher] 
6. 5.Under Setting -> TranslatePress pleas remove the ticke from 'Floating language selection', to remove the existing language selection switch